### PR TITLE
Fix broken image links

### DIFF
--- a/modules/branded_android_app/pages/building_branded_android_client.adoc
+++ b/modules/branded_android_app/pages/building_branded_android_client.adoc
@@ -8,15 +8,15 @@ Building an Android app requires just a few images, and the wizard tells you the
 
 First, start on the Common tab and enter your application name and the URL to your ownCloud server. For testing purposes these can be anything. These are your global defaults, and you can change them when you create your apps. When you create production apps, then you must use your real app name, and the URL must point to your real ownCloud server.
 
-image:images/ownbrander-5.png[image]
+image:ownbrander-5.png[image]
 
 Next, go to the Android tab. This has three sections: *Required*, *Suggested*, and *Advanced*. Start in the *Required* section with your application name and server URL, which should be already entered from the Common tab. You may change these, and optionally check *Server URL visible* to allow users to change it.
 
-image:images/ownbrander-29.png[image]
+image:ownbrander-29.png[image]
 
 Now enter your Android package name. This is the unique name that identifies it to Google Play. Then enter your account type; this identifies it on your users’ Android devices.
 
-image:images/ownbrander-6.png[image]
+image:ownbrander-6.png[image]
 
 Your next three options are *Show multiaccount or disconnect*, *Enable send to other apps features*, and *Enable SAML*. When you enable *Show multiaccount or disconnect*, your users can configure multiple ownCloud accounts. When it is disabled they see only a disconnect button.
 
@@ -26,11 +26,11 @@ Your next three options are *Show multiaccount or disconnect*, *Enable send to o
 
 Next, upload your images. The wizard tells you the exact size they must be, and you can click the images on the right to see some example screenshots.
 
-image:images/ownbrander-7.png[image]
+image:ownbrander-7.png[image]
 
 You may enter a custom user agent, if you wish, and display a new account link button to your users. You need this to enable multiaccounts.
 
-image:images/ownbrander-8.png[image]
+image:ownbrander-8.png[image]
 
 [[signing-android-client]]
 == Signing Android Client
@@ -53,10 +53,10 @@ Enter any custom download link in *URL to download the app*.
 
 Finally, if you are creating a paid app then check the checkbox for *Paid Users* and upload an icon.
 
-image:images/ownbrander-11.png[image]
+image:ownbrander-11.png[image]
 
 The *Suggested* and *Advanced* sections allow you to further customize your branding with custom colors and images.
 
 When you are finished click the *Generate Android App* button, and you will either see a success message, or an error message telling you what you need to fix. Note also that at the bottom of the wizard, the name and version of your new app is displayed, for example *The version that it will be generated is: oc-android-2.0.0_signed*. When all of your options are entered correctly and you click the Generate Android App button, it takes up to 48 hours for your app to appear in your https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account.
 
-image:images/ownbrander-12.png[image]
+image:ownbrander-12.png[image]

--- a/modules/branded_android_app/pages/publishing_android_app.adoc
+++ b/modules/branded_android_app/pages/publishing_android_app.adoc
@@ -60,11 +60,11 @@ Mac OS X and Windows users can download the Oracle JDK from http://www.oracle.co
 
 `zipalign` is included in the https://developer.android.com/sdk/index.html[Android Software Development Kit]. It is a large download, but once you have downloaded it you can copy the `zipalign` binary to any computer and use it. Go to https://developer.android.com/sdk/index.html[Android Software Development Kit] and click the ``Download Android Studio'' button.
 
-image:images/android_custom_17.png[image]
+image:android_custom_17.png[image]
 
 Download the appropriate *SDK Tools Only* package for your operating system.
 
-image:images/android_custom_18.png[image]
+image:android_custom_18.png[image]
 
 Unpack it and change to the unpacked directory, which is `android-sdk-linux` on Linux systems, `android-sdk-macosx` on Mac systems, and `android-sdk-windows` on Windows systems. There is one more step, and that is to install additional tools. Run this command from the unpacked directory:
 
@@ -177,15 +177,15 @@ Again, this emits a lot of output, and when you see *Verification succesful* at 
 
 You can download your branded Android app from your account on https://customer.owncloud.com/owncloud[Customer.owncloud.com], and send it as an email attachment to your users. (This is not the optimal way to distribute it as it is over 2 megabytes in size.) When they open your email on their Android phone or tablet, they must first click the the download arrow (bottom right of the screenshot) to download your app.
 
-image:images/android_custom_1.png[image]
+image:android_custom_1.png[image]
 
 When the arrow changes to a green checkbox, it has been downloaded.
 
-image:images/android_custom_2.png[image]
+image:android_custom_2.png[image]
 
 Now your user must click on the green checkbox, and this launches the app installer, and all they have to do is follow the installation wizard to install your branded app.
 
-image:images/android_custom_3.png[image]
+image:android_custom_3.png[image]
 
 When the installation is complete, the https://doc.owncloud.com/android/[ownCloud Android App Manual] contains instructions for using the app.
 
@@ -212,31 +212,31 @@ Start at Google’s http://developer.android.com/distribute/googleplay/start.htm
 
 Google’s process for uploading apps is fairly streamlined, and the most time-consuming task is creating all the required graphics. After registering, you’ll see the welcome screen for the Google Dev Console. Click *Publish an Android app on Google Play*.
 
-image:images/android_custom_6.png[image]
+image:android_custom_6.png[image]
 
 This opens the *Add New Application* screen. Click the *Prepare Store Listing* button. (Note that as you navigate the various screens, you can click the Save Draft button to preserve your changes.)
 
-image:images/android_custom_7.png[image]
+image:android_custom_7.png[image]
 
 On the next screen, enter your product description.
 
-image:images/android_custom_8.png[image]
+image:android_custom_8.png[image]
 
 Then you’ll have to upload a batch of graphics in various sizes for the *Graphic Assets* section, like these images for a smartphone and seven-inch tablet. You are required to upload at least two images.
 
-image:images/android_custom_9.png[image]
+image:android_custom_9.png[image]
 
 You must also upload a 512x512-pixel logo, and a 1024x500 banner.
 
-image:images/android_custom_10.png[image]
+image:android_custom_10.png[image]
 
 Now choose the store categories for your app.
 
-image:images/android_custom_11.png[image]
+image:android_custom_11.png[image]
 
 Then enter your contact information, which will be visible on your store listing.
 
-image:images/android_custom_12.png[image]
+image:android_custom_12.png[image]
 
 On the next line you may optionally link to your privacy policy. It is recommended to have a privacy policy.
 
@@ -244,7 +244,7 @@ When you’re finished with the *Store Listing* page, go to the *Pricing and Dis
 
 For now let’s make this a free app, so click the Free button and select the countries you want to distribute it in.
 
-image:images/android_custom_13.png[image]
+image:android_custom_13.png[image]
 
 Now you may upload your app.
 
@@ -253,35 +253,35 @@ Now you may upload your app.
 
 Now you can upload your app to your Google Play Store page. Go to the *APK* page and click *Upload your first APK to Production*. You don’t need a license key for a free app.
 
-image:images/android_custom_14.png[image]
+image:android_custom_14.png[image]
 
 Drag-and-drop, or browse to select your app.
 
-image:images/android_custom_15.png[image]
+image:android_custom_15.png[image]
 
 A successful upload looks like this:
 
-image:images/android_custom_20.png[image]
+image:android_custom_20.png[image]
 
 Your app is not yet published, but only uploaded to your account. There is one more step to take before you can publish, and that is to go back to the *Pricing & Distribution* page and fill out the *Consent* section.
 
-image:images/android_custom_21.png[image]
+image:android_custom_21.png[image]
 
 Click the Save Draft button, and if you followed all the required steps you should now see a *Publish App* button.
 
-image:images/android_custom_22.png[image]
+image:android_custom_22.png[image]
 
 It will not be published immediately, but after review by Google, which usually takes just a few hours.
 
-image:images/android_custom_23.png[image]
+image:android_custom_23.png[image]
 
 After it has been published, your store listing is updated as PUBLISHED, and it includes a link to your Play Store listing.
 
-image:images/android_custom_24.png[image]
+image:android_custom_24.png[image]
 
 Now all you need to do is distribute the URL to your users, and they can install it either from their Web browsers, or from their Google Play Store apps. This is how it looks to your users.
 
-image:images/android_custom_25.png[image]
+image:android_custom_25.png[image]
 
 [[customize-download-link]]
 == Customize Download Link
@@ -320,7 +320,7 @@ If you would rather not give your branded app away you can sell it on Google Pla
 
 You must establish a Google Wallet Merchant Account. On your Google Dev Console click the *Learn more* link under the Free/Paid button for a nice thorough review of the process and tools. It requires verifying your business information and bank account, and you should expect it to take 3-4 days.
 
-image:images/android_custom_26.png[image]
+image:android_custom_26.png[image]
 
 When you’re ready to set it up, click the *Set up a merchant account now* link under the Free/Paid button.
 

--- a/modules/branded_desktop_client/pages/branded_desktop_client.adoc
+++ b/modules/branded_desktop_client/pages/branded_desktop_client.adoc
@@ -8,7 +8,7 @@ Start with the Common section at the top, and enter information common to all cl
 
 Then go to the Desktop client section of ownBrander, which has two sections, Required and Optional.
 
-image:images/ownbrander-2.png[ownBrander screen for desktop client.]
+image:ownbrander-2.png[ownBrander screen for desktop client.]
 
 Work your way through the wizard, entering required elements and any optional elements you wish. When you have completed the wizard, press the *Generate Desktop Client* button. You will either get messages warning you of any items that need to be corrected, or a success message:
 

--- a/modules/branded_ios_app/pages/publishing_ios_app_2.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_2.adoc
@@ -4,62 +4,62 @@
 
 Start by creating a .certSigningRequest (CSR) file on your Mac, using Keychain Access. Open Finder, and then open Keychain Access from the Utilities folder.
 
-image:images/mac-1.png[image]
+image:mac-1.png[image]
 
 Next, open *Keychain Access > Certificate Assistant > Request a Certificate From a Certificate Authority*.
 
-image:images/mac-2.png[image]
+image:mac-2.png[image]
 
 Enter the email address that you use in your Apple developer account, and enter a common name. The common name can be anything you want, for example a helpful descriptive name like ``ios-mybiz''. Check *Saved to disk* and *Let me specify key pair information*, then click *Continue*.
 
-image:images/mac-3.png[image]
+image:mac-3.png[image]
 
 Give your CSR a helpful descriptive name, such as *iosapp.certSigningRequest*, and choose the location to save it on your hard drive, then click *Save*.
 
-image:images/mac-4.png[image]
+image:mac-4.png[image]
 
 In the next window, set the *Key Size* value to *2048 bits* and *Algorithm* to *RSA*, and click *Continue*. This will create and save your certSigningRequest file (CSR) to your hard drive.
 
-image:images/mac-5.png[image]
+image:mac-5.png[image]
 
 In the next screen your certificate creation is verified. Click a button to view it, or click *Done* to go to the next step.
 
-image:images/mac-6.png[image]
+image:mac-6.png[image]
 
 You also get a corresponding public and private key pair, which you can see in the *Login > Keys* section of Keychain.
 
-image:images/mac-7.png[image]
+image:mac-7.png[image]
 
 Double-click on your new private key to open the Access Control dialog. Check *Allow all applications to access this item*.
 
-image:images/mac-8.png[image]
+image:mac-8.png[image]
 
 Now login to the *Member Center* on https://developer.apple.com/. Click *Certificates, Identifiers, & Profiles*.
 
-image:images/cert-1.png[image]
+image:cert-1.png[image]
 
 Then click *iOS Apps > Certificates*.
 
-image:images/cert-2.png[image]
+image:cert-2.png[image]
 
 Next, click the add button (the little plus sign) in the top right corner of the *iOS Certificate* page.
 
-image:images/cert-3.png[image]
+image:cert-3.png[image]
 
 Under ``What type of certificate do you need?'' check *App Store and Ad Hoc*, then click the *Continue* button at the bottom of the page.
 
-image:images/cert-4.png[image]
+image:cert-4.png[image]
 
 The next screen, *About Creating a Certificate Signing Request (CSR)* has information about creating a CSR in Keychain Access. You already did this, so go to the next screen. ``Add iOS Certificate'', to upload the CSR you already created, then click the *Generate* button.
 
-image:images/cert-5.png[image]
+image:cert-5.png[image]
 
 Your new certificate is named *ios_distribution.cer*. Download it to your Mac; then find it and double-click on it to install it properly in Keychain.
 
-image:images/cert-6.png[image]
+image:cert-6.png[image]
 
 After installing it, you should see it stored with its corresponding private key in Keychain.
 
-image:images/cert-7.png[image]
+image:cert-7.png[image]
 
 Remember to make backups of your keys and certificates and keep them in a safe place.

--- a/modules/branded_ios_app/pages/publishing_ios_app_3.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_3.adoc
@@ -9,54 +9,54 @@ The next step is to create four *Bundle IDs*. These are unique identifiers for y
 
 Now you must create your App ID. Go to *Identifiers > App IDs* and click the plus button (top right) to open the ``Register iOS App ID'' screen. Fill in your *App ID Description*, which is anything you want, so make it helpful and descriptive. The *App ID Prefix* is your Apple Developer Team ID, and is automatically entered for you.
 
-image:images/cert-8.png[image]
+image:cert-8.png[image]
 
 Scroll down to the *App ID Suffix* section and create your *Bundle ID*. Your *Bundle ID* is the unique identifier for your app. Make a note of it because you will need it as you continue through this process. The format for your *Bundle ID* is reverse-domain, e.g. _com.MyCompany.MyProductName_.
 
-image:images/cert-9.png[image]
+image:cert-9.png[image]
 
 The next section, *App Services*, is where you select the services you want enabled in your app. You can edit this anytime after you finish creating your *App ID*. Check *App Groups*, make your other selections and then click the *Continue* button at the bottom. Now you can confirm all of your information. If everything is correct click *Submit*; if you need to make changes use the *Back* button.
 
-image:images/cert-11.png[image]
+image:cert-11.png[image]
 
 When you are finished you will see a confirmation. Click the *Done* button at the bottom.
 
-image:images/cert-12.png[image]
+image:cert-12.png[image]
 
 [[create-app-group]]
 == Create App Group
 
 The next step is to create an App Group and put your App ID in it. Go to *Identifiers > App Groups* and click the plus button (top right).
 
-image:images/cert-13.png[image]
+image:cert-13.png[image]
 
 Create a description for your app group, and a unique identifier in the format _group.com.MyCompany.MyAppGroup_. Then click *Continue*
 
-image:images/cert-14.png[image]
+image:cert-14.png[image]
 
 Review the confirmation screen, and if everything looks correct click the *Register* button.
 
-image:images/cert-15.png[image]
+image:cert-15.png[image]
 
 You’ll see a final confirmation screen; click *Done*.
 
-image:images/cert-16.png[image]
+image:cert-16.png[image]
 
 When you click on *App Groups* you will see your new app group.
 
-image:images/cert-17.png[image]
+image:cert-17.png[image]
 
 Now go back to *Identifiers > App IDs* and click on your App ID. This opens a screen that displays all your app information. Click the *Edit* button at the bottom.
 
-image:images/cert-18.png[image]
+image:cert-18.png[image]
 
 Click the *Edit* button next to *App Groups*.
 
-image:images/cert-19.png[image]
+image:cert-19.png[image]
 
 Check your app and click the *Continue* button.
 
-image:images/cert-20.png[image]
+image:cert-20.png[image]
 
 The next screen asks you to ``Review and confirm the App Groups you have selected''. Click the *Assign* button to confirm. The next screen announces ``You have successfully updated the App Groups associations with your App ID'', and you must click yet another button, the *Done* button at the bottom.
 
@@ -65,25 +65,25 @@ The next screen asks you to ``Review and confirm the App Groups you have selecte
 
 Now you must return to *Identifiers > App IDs* and click the plus button to create a DocumentProvider Bundle ID. Follow the same naming conventions as for your App ID, then click *Continue*.
 
-image:images/cert-25.png[image]
+image:cert-25.png[image]
 
 Confirm your new App ID and click *Submit*.
 
-image:images/cert-26.png[image]
+image:cert-26.png[image]
 
 You will see one more confirmation: ``Registration complete. This App ID is now registered to your account and can be used in your provisioning profiles.'' Click *Done*.
 
 Now you need to add it to your App Group. Go to *Identifiers > App IDs* and click on your new DocumentProvider Bundle ID to open its configuration window, and then click the *Edit* button at the bottom.
 
-image:images/cert-27.png[image]
+image:cert-27.png[image]
 
 Select *App Groups* and click the *Edit* button.
 
-image:images/cert-28.png[image]
+image:cert-28.png[image]
 
 Select your group and click *Continue*.
 
-image:images/cert-29.png[image]
+image:cert-29.png[image]
 
 Once again you will asked if you really mean it. On the confirmation screen click *Assign*, and you’ll see the message ``You have successfully updated the App Groups associations with your App ID.''
 
@@ -92,23 +92,23 @@ Once again you will asked if you really mean it. On the confirmation screen clic
 
 One more time, go to *Identifiers > App IDs* and click the plus button to create a DocumentProviderFileProvider Bundle ID. Follow the same naming conventions as for your App ID, then click *Continue*.
 
-image:images/cert-30.png[image]
+image:cert-30.png[image]
 
 Confirm your new App ID and click *Submit*.
 
-image:images/cert-31.png[image]
+image:cert-31.png[image]
 
 You will see one more confirmation; review it and click *Done*. Now you need to add it to your App Group. Go to *Identifiers > App IDs* and click on your new DocumentProviderFileProvider Bundle ID to open its configuration window, and then click the *Edit* button.
 
-image:images/cert-32.png[image]
+image:cert-32.png[image]
 
 Select *App Groups* and click the *Edit* button.
 
-image:images/cert-33.png[image]
+image:cert-33.png[image]
 
 Select your group and click *Continue*.
 
-image:images/cert-34.png[image]
+image:cert-34.png[image]
 
 On the confirmation screen click *Assign*, and you’ll see the message ``You have successfully updated the App Groups associations with your App ID.''
 
@@ -119,23 +119,23 @@ This supports Apple’s ShareIN extension.
 
 Yet again, go to *Identifiers > App IDs* and click the plus button to create a ShareExtApp Bundle ID. Follow the same naming conventions as for your App ID, then click *Continue*.
 
-image:images/cert-53.png[image]
+image:cert-53.png[image]
 
 Confirm your new App ID and click *Submit*.
 
-image:images/cert-54.png[image]
+image:cert-54.png[image]
 
 You will see one more confirmation; review it and click *Done*. Now you need to add it to your App Group. Go to *Identifiers > App IDs* and click on your new ShareExtApp Bundle ID to open its configuration window, and then click the *Edit* button.
 
-image:images/cert-55.png[image]
+image:cert-55.png[image]
 
 Select *App Groups* and click the *Edit* button.
 
-image:images/cert-56.png[image]
+image:cert-56.png[image]
 
 Select your group and click *Continue*.
 
-image:images/cert-57.png[image]
+image:cert-57.png[image]
 
 On the confirmation screen click *Assign*, and you’ll see the message ``You have successfully updated the App Groups associations with your App ID.''
 
@@ -144,4 +144,4 @@ On the confirmation screen click *Assign*, and you’ll see the message ``You ha
 
 Now you should have four new App IDs, and all of them should belong to your App Group.
 
-image:images/cert-37.png[image]
+image:cert-37.png[image]

--- a/modules/branded_ios_app/pages/publishing_ios_app_4.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_4.adoc
@@ -16,11 +16,11 @@ And you must register the UDID of each device in your Apple developer account. I
 
 The easiest way to find UDIDs is to connect to your iTunes account. Then connect your iOS device to your Mac computer. Your device will appear on the left sidebar in iTunes. Click on this to display your device information. Then click on the serial number, and you will see your UDID.
 
-image:images/itunes-udid.png[image]
+image:itunes-udid.png[image]
 
 Return to your account on https://developer.apple.com[Developer.apple.com], go to *IOS Apps > Devices > All*, and click the plus button on the top right to register a new device. You can make the name anything you want, and the UDID must be the UDID copied from iTunes.
 
-image:images/itunes-udid-3.png[image]
+image:itunes-udid-3.png[image]
 
 If you have a large number of devices to register, you may enter them in a text file in this format, and then upload the file:
 
@@ -32,6 +32,6 @@ B123456789012345678901234567890123456789   NAME2
 
 Click *Download sample files* to see examples of plain text and markup files.
 
-image:images/itunes-udid-4.png[image]
+image:itunes-udid-4.png[image]
 
 When you are finished entering your device IDs click the *Continue* button. Verify, and then click *Done*.

--- a/modules/branded_ios_app/pages/publishing_ios_app_5.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_5.adoc
@@ -9,54 +9,54 @@ The next phase of this glorious journey is to create eight provisioning profiles
 
 Go to *Provisioning Profiles > All*, then click the plus button (top right) to open the _Add iOS Provisioning Profile_ screen. Select *Ad Hoc* and click *Continue*.
 
-image:images/cert-35.png[image]
+image:cert-35.png[image]
 
 On the *Select App ID* screen select the first of the three App IDs that you created and click *Continue*. (The first one has the shortest name, if you followed the naming conventions in this manual.)
 
-image:images/cert-36.png[image]
+image:cert-36.png[image]
 
 Select the certificate that you created at the beginning of this process and click *Continue*.
 
-image:images/cert-38.png[image]
+image:cert-38.png[image]
 
 Select the devices that you want to install and test your app on, then click *Continue*.
 
-image:images/cert-39.png[image]
+image:cert-39.png[image]
 
 Name your provisioning profile with a descriptive *Profile Name* and click *Generate*.
 
-image:images/cert-40.png[image]
+image:cert-40.png[image]
 
 When it has generated, download your new profile to your Mac computer.
 
-image:images/cert-50.png[image]
+image:cert-50.png[image]
 
 Find it on your Mac (usually the Download folder) and double-click to install it in Xcode.
 
-image:images/cert-41.png[image]
+image:cert-41.png[image]
 
 [[second-ad-hoc-provisioning-profile]]
 == Second Ad Hoc Provisioning Profile
 
 Return to the ``Your provision profile is ready'' screen, scroll to the bottom and click *Add Another*. On the following screen select *Ad Hoc* and click *Continue*.
 
-image:images/cert-35.png[image]
+image:cert-35.png[image]
 
 This time select the *.DocumentProvider* app ID and click *Continue*.
 
-image:images/cert-42.png[image]
+image:cert-42.png[image]
 
 Select the certificate that you created at the beginning of this process and click *Continue*.
 
-image:images/cert-43.png[image]
+image:cert-43.png[image]
 
 Select the devices that you want to install and test your app on, then click *Continue*. These must be the same devices you selected for the first provisioning profile.
 
-image:images/cert-39.png[image]
+image:cert-39.png[image]
 
 Give this provisioning profile the same name as your first profile, plus *.DocumentProvider* and click *Generate*.
 
-image:images/cert-44.png[image]
+image:cert-44.png[image]
 
 Just like the first provisioning profile, download it to your Mac computer, and then double-click to install it in Xcode.
 
@@ -65,23 +65,23 @@ Just like the first provisioning profile, download it to your Mac computer, and 
 
 Return to the ``Your provision profile is ready'' screen, scroll to the bottom and click *Add Another*. On the following screen select *Ad Hoc* and click *Continue*.
 
-image:images/cert-35.png[image]
+image:cert-35.png[image]
 
 This time select the *.DocumentProviderFileProvider* app ID and click *Continue*.
 
-image:images/cert-60.png[image]
+image:cert-60.png[image]
 
 Select the certificate that you created at the beginning of this process and click *Continue*.
 
-image:images/cert-43.png[image]
+image:cert-43.png[image]
 
 Select the devices that you want to install and test your app on, then click *Continue*. These must be the same devices you selected for the first provisioning profile.
 
-image:images/cert-39.png[image]
+image:cert-39.png[image]
 
 Give this provisioning profile the same name as your first profile plus *.DocumentProviderFileProvider* and click *Generate*. There is a 50-character limit, but don’t worry about counting characters because it will be automatically truncated if you go over.
 
-image:images/cert-47.png[image]
+image:cert-47.png[image]
 
 Download it to your Mac computer, and then double-click to install it in Xcode.
 
@@ -90,38 +90,38 @@ Download it to your Mac computer, and then double-click to install it in Xcode.
 
 Return to the ``Your provision profile is ready'' screen, scroll to the bottom and click *Add Another*. On the following screen select *Ad Hoc* and click *Continue*.
 
-image:images/cert-35.png[image]
+image:cert-35.png[image]
 
 This time select the *.ShareExtApp* app ID and click *Continue*.
 
-image:images/cert-46.png[image]
+image:cert-46.png[image]
 
 Select the certificate that you created at the beginning of this process and click *Continue*.
 
-image:images/cert-43.png[image]
+image:cert-43.png[image]
 
 Select the devices that you want to install and test your app on, then click *Continue*. These must be the same devices you selected for the first provisioning profile.
 
-image:images/cert-39.png[image]
+image:cert-39.png[image]
 
 Give this provisioning profile the same name as your first profile plus *.ShareExtApp* and click *Generate*. There is a 50-character limit, but don’t worry about counting characters because it will be automatically truncated if you go over.
 
-image:images/cert-58.png[image]
+image:cert-58.png[image]
 
 Download it to your Mac computer, and then double-click to install it in Xcode. You should now see all of your Ad Hoc provisioning profiles listed in your ``iOS Provisioning Profiles''.
 
-image:images/cert-59.png[image]
+image:cert-59.png[image]
 
 [[create-four-app-store-profiles]]
 == Create Four App Store Profiles
 
 Creating your four App Store profiles is the same as creating your Ad Hoc profiles, except that when you start you check the App Store checkbox, and you won’t select testing devices.
 
-image:images/cert-62.png[image]
+image:cert-62.png[image]
 
 When you’re finished, you’ll have eight new provisioning profiles. Remember, when you build your app on ownBuilder you only send in the four Ad Hoc profiles, plus your P12 certificate.
 
-image:images/cert-61.png[image]
+image:cert-61.png[image]
 
 Go to the next page to learn how to create your P12 certificate 
 <publishing_ios_app_6>.

--- a/modules/branded_ios_app/pages/publishing_ios_app_6.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_6.adoc
@@ -4,26 +4,26 @@ Creating a P12 Certificate
 
 In addition to emailing your four Ad Hoc provisioning profiles to support@owncloud.com, you must also include your P12 certificate. To create this, return to Keychain Access on your Mac computer and find your private key that you created at the beginning (see publishing_ios_app_2).
 
-image:images/ios-p12.png[image]
+image:ios-p12.png[image]
 
 Right-click on your private key and left-click *Export [your key name]*.
 
-image:images/ios-p12-2.png[image]
+image:ios-p12-2.png[image]
 
 Enter any name you want, the location you want to save it to, and click *Save*.
 
-image:images/ios-p12-3.png[image]
+image:ios-p12-3.png[image]
 
 In the next screen you have the option to enter a password. If you put a password on your P12 certificate you will have to include it when you send your certificate and provisioning profiles to support@owncloud.com. Click *OK*.
 
-image:images/ios-p12-4.png[image]
+image:ios-p12-4.png[image]
 
 On the next screen you must enter your login keychain password, which is your Mac login password, and click *Allow*.
 
-image:images/ios-p12-5.png[image]
+image:ios-p12-5.png[image]
 
 Now your new P12 certificate should be in the directory you saved it in.
 
-image:images/ios-p12-6.png[image]
+image:ios-p12-6.png[image]
 
 You have now completed all the necessary steps for signing your branded iOS app. The next step is to build your app with the ownBrander app on https://customer.owncloud.com.

--- a/modules/branded_ios_app/pages/publishing_ios_app_7.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_7.adoc
@@ -4,7 +4,7 @@
 
 At long last you have arrived at the point where you can actually build your branded iOS app. Log into your account on https://customer.owncloud.com/owncloud/[Customer.owncloud.com/owncloud] and open the ownBrander app.
 
-image:images/ownbrander-1.png[image]
+image:ownbrander-1.png[image]
 
 If you don’t see the ownBrander app, open a support request (*Open Case* button).
 
@@ -19,83 +19,83 @@ When you have completed and submitted your app, email your three provisioning pr
 
 Enter your application name. This can be anything; in this example it is the same name used in our signing certificate examples.
 
-image:images/ownbrander-13.png[image]
+image:ownbrander-13.png[image]
 
 Next, enter your ownCloud server URL. This hard-codes it into your app. If you leave this blank then your users will have to enter it every time they use the app.
 
-image:images/ownbrander-15.png[image]
+image:ownbrander-15.png[image]
 
 Check *Server URL Visible* to make your ownCloud server URL the default, and to allow your users to enter a different URL.
 
-image:images/ownbrander-16.png[image]
+image:ownbrander-16.png[image]
 
 And now, the all-important *Bundle ID*. Make sure that this is exactly the same as the *Bundle ID* you created on link:developer.apple.com[Developer.apple.com] (see publishing_ios_app_3).
 
-image:images/ownbrander-17.png[image]
+image:ownbrander-17.png[image]
 
 You must also enter the *App Group* you created.
 
-image:images/ownbrander-18.png[image]
+image:ownbrander-18.png[image]
 
 Check *Show multi-account or disconnect* if you plan to allow your users to have more than one ownCloud account.
 
-image:images/ownbrander-19.png[image]
+image:ownbrander-19.png[image]
 
 Check *Enable SAML* authentication if that is what you use on your ownCloud server. Otherwise leave it blank.
 
-image:images/ownbrander-20.png[image]
+image:ownbrander-20.png[image]
 
 *Number of uploads shown* controls the length of the most recent uploads list on the app. The default is 30.
 
-image:images/ownbrander-21.png[image]
+image:ownbrander-21.png[image]
 
 The next section is for uploading your custom artwork to be built into the app. The ownBuilder app tells you exactly which images you need, and their required size. You only need one Splash Screen image, and ownBrander will automatically resize and crop it for different-sized screens. You must also select a background color, which ensures that the splash screen image is always at the correct size ratio. (Click the example images on the right to enlarge them.)
 
-image:images/ownbrander-14.png[image]
+image:ownbrander-14.png[image]
 
 You may enter a custom *User agent*, which is useful for traffic analysis and whitelisting your app.
 
-image:images/ownbrander-22.png[image]
+image:ownbrander-22.png[image]
 
 Check *Recommend* to open a Twitter, Facebook, and Email recommendation configurator.
 
-image:images/ownbrander-23.png[image]
+image:ownbrander-23.png[image]
 
 If you have online help, enter the URL here.
 
-image:images/ownbrander-24.png[image]
+image:ownbrander-24.png[image]
 
 *Activate the option feedback* creates an option for your users to either enable or not enable the feedback option on their devices. If you enable this, enter your *Feedback email* address.
 
-image:images/ownbrander-25.png[image]
+image:ownbrander-25.png[image]
 
 Enter your *Imprint URL* (your ``about'' page)
 
-image:images/ownbrander-26.png[image]
+image:ownbrander-26.png[image]
 
 Check *Show a ``new account'' link in app* to allow new users to request a new account.
 
-image:images/ownbrander-27.png[image]
+image:ownbrander-27.png[image]
 
 Upload an icon that will be displayed by default when there is no file preview to display.
 
-image:images/ownbrander-30.png[image]
+image:ownbrander-30.png[image]
 
 By default, both internal sharing and sharing by link are enabled. You have the options to disable one or both of these.
 
-image:images/ownbrander-31.png[image]
+image:ownbrander-31.png[image]
 
 You may disable background transfers if you are using mobile device management (MDM), such as Mobile Iron, that does not support background jobs, or if you simply do not want to allow the app to work in the background. By default, the ownCloud iOS app supports background file transfers by taking advantage of link:[Background Execution. <https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/ iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html>]
 
-image:images/ownbrander-32.png[image]
+image:ownbrander-32.png[image]
 
 The default version number of your branded app is the same as the official ownCloud app. You have the option to customize your version number. Once you do this, you will have to update it manually for new releases. This must be the same as the version number that you enter in iTunes. Your version number is visible to your users.
 
-image:images/ownbrander-33.png[image]
+image:ownbrander-33.png[image]
 
 You may also customize the build number, which defaults to 1.0.0. This must also be manually updated when you customize it. Your build number is used by iTunes to uniquely identify your app. When the build number changes, iTunes automatically syncs the updates for your users. The build number is not visible to your users.
 
-image:images/ownbrander-34.png[image]
+image:ownbrander-34.png[image]
 
 That completes the required elements of your branded iOS app.
 
@@ -114,7 +114,7 @@ The Advanced section allows you to optionally customize the color of messages su
 
 When you have uploaded all of your images and completed your customizations, click the *Generate iOS App* button and take a well-deserved break. Remember to email your four Ad Hoc provisioning profiles and P12 certificate to support@owncloud.com.
 
-image:images/ownbrander-28.png[image]
+image:ownbrander-28.png[image]
 
 You may go back and make changes, and when you click the *Generate iOS App* button the build system will use your latest changes.
 

--- a/modules/branded_ios_app/pages/publishing_ios_app_9.adoc
+++ b/modules/branded_ios_app/pages/publishing_ios_app_9.adoc
@@ -9,19 +9,19 @@ Apple must review and approve your app, and the approval process can take severa
 Download your xcarchive.zip file from your account on https://customer.owncloud.com/owncloud. Your friendly Mac computer will automatically unpack it and change the name to something like Owncloud 
 iOs Client 02-07-15 10.30.xcarchive. Double-click on this file to automatically install it into Xcode. Go to Xcode and you will see it in the Archives listing under *Window > Organizer*.
 
-image:images/ios-publish-2.png[_figure 1_]
+image:ios-publish-2.png[_figure 1_]
 
 Next, go back to the https://developer.apple.com/membercenter/index.action[Apple Developer Member Center] to log into iTunes Connect to set up your app storefront.
 
-image:images/ios-publish-3.png[_figure 2_]
+image:ios-publish-3.png[_figure 2_]
 
 After logging in click the blue *My Apps* button. This takes you to the main screen for managing your apps on iTunes.
 
-image:images/ios-publish.png[_figure 3_]
+image:ios-publish.png[_figure 3_]
 
 Click the plus button on the top left to setup your new branded iOS app.
 
-image:images/ios-publish-4.png[_figure 4_]
+image:ios-publish-4.png[_figure 4_]
 
 This opens a screen where you will enter your app information. Make sure you get it right the first time, because it is difficult to delete apps, and Apple will not let you re-use your app name or SKU.
 
@@ -33,15 +33,15 @@ This opens a screen where you will enter your app information. Make sure you get
 
 Then click the *Create* button.
 
-image:images/ios-publish-5.png[_figure 5_]
+image:ios-publish-5.png[_figure 5_]
 
 Now go back to your Xcode organizer to upload your app; click the blue *Submit to App Store* button.
 
-image:images/ios-publish-6.png[_figure 6_]
+image:ios-publish-6.png[_figure 6_]
 
 This takes a few minutes as it verifies your bundle ID and certificates, and then you will see an upload status.
 
-image:images/ios-publish-7.png[_figure 7_]
+image:ios-publish-7.png[_figure 7_]
 
 At long last, after working through this long complex process, you are almost ready to publish your app on iTunes.
 
@@ -50,11 +50,11 @@ At long last, after working through this long complex process, you are almost re
 
 There are just a few steps remaining. Now that you have uploaded your branded iOS app, you need to upload some screenshots, an optional demo video, and fill in some information for your app listing on your iTunes storefront. You should see something like this on your main screen (figure 8). You should click the *Save* button at the top right periodically to preserve your changes.
 
-image:images/ios-publish-8.png[_figure 8_]
+image:ios-publish-8.png[_figure 8_]
 
 This screen displays all of your apps and their submission status. Click *Prepare for Submission* to get started on the submission process. The first screen is for entering screenshots of your app for various devices, and optionally a demonstration video. Click the little question marks to learn the required image specifications.
 
-image:images/ios-publish-9.png[image]
+image:ios-publish-9.png[image]
 
 Apple simplified the screenshot submission process: https://developer.apple.com/news/?id=08082016a
 
@@ -70,21 +70,21 @@ __________
 
 Then you must enter your app name, a description, some keywords for iTunes searches, and some optional URLs.
 
-image:images/ios-publish-10.png[_figure 10_]
+image:ios-publish-10.png[_figure 10_]
 
 The next section is for Apple Watch. If you don’t support Apple Watch you can skip this.
 
 The *General App Information* section requires a 1024x1024 logo, version, rating, category, license, copyright, and contact information.
 
-image:images/ios-publish-11.png[_figure 11_]
+image:ios-publish-11.png[_figure 11_]
 
 In the *Build* section, click the plus button and select your app.
 
-image:images/ios-publish-14.png[_figure 12_]
+image:ios-publish-14.png[_figure 12_]
 
 The *App Review Information* requires contact information, and some information about your app to guide reviewers. Remember, everyone on iTunes can review your app, so it’s in your best interest to be helpful. You may optionally provide a login for a demo account.
 
-image:images/ios-publish-12.png[_figure 13_]
+image:ios-publish-12.png[_figure 13_]
 
 The *Version Release* section allows you to choose between automatic release, which means your app will be published upon approval, or manual release, where you must release your app after it is approved.
 
@@ -93,7 +93,7 @@ The *Version Release* section allows you to choose between automatic release, wh
 
 Next, you must go to the *Pricing* page to set your price, and to select the terroritories you want your app to be available in.
 
-image:images/ios-publish-13.png[_figure 14_]
+image:ios-publish-13.png[_figure 14_]
 
 [[submit-for-review]]
 == Submit For Review
@@ -109,6 +109,6 @@ You are now finished. No really, you are. When you return to your *My Apps* page
 
 Here are the most common answers <faq_ios_app_review_team> to questions from the iOS App Review Team.
 
-image:images/ios-publish-15.png[_figure 15_]
+image:ios-publish-15.png[_figure 15_]
 
 When, at last, it is published on iTunes you may distribute the URL so that your users may install and use your app.


### PR DESCRIPTION
This PR corrects all the image links created by Pandoc. 

:tipping_hand_woman: Pandoc did a lot of the required work, but doesn't know about Antora's {imagesdir}. Given that, it could never fully migrate the images link. So this PR fixes the images links so that they refer to the {imagesdir}. 