### PR TITLE
Fix broken link on repo home page

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = Branded Clients
 
-
-See the https://github.com/owncloud/branded_clients/wiki/Branded-ownCloud-Clients-FAQ[FAQ for additional information] such as logging into multiple servers, error messages, cryptography export exemptions, and issues with publishing on iTunes.
+* xref:branded_desktop_client/branded_desktop_client.adoc[Building a Branded Desktop Sync Client]
+* xref:branded_ios_app/publishing_ios_app.adoc[Creating Branded iOS Apps]
+* xref:branded_android_app/building_branded_android_client.adoc[Building Branded Android Apps]


### PR DESCRIPTION
This removes the non-existent FAQ link, replacing it with a simple toc
to the core pages of the content.