### PR TITLE
Replace incorrect publishing Android content in iOS section

### DIFF
--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_9.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_9.adoc
@@ -1,378 +1,147 @@
-= Distributing Your Branded Android App
+= Publishing Your New Branded iOS App
+:experimental:
+:screenshot-submission-process-url: https://developer.apple.com/news/?id=08082016a
+:screenshot-submission-process-video-url: https://developer.apple.com/videos/play/wwdc2016/305/?time=1700
+:sized-frames-url: https://itunes.apple.com/app/owncloud/id543672169
+:owncloud-customer-url: https://customer.owncloud.com/owncloud
 
+At last, after following all the previous steps and passing beta testing, your branded iOS app is ready to publish for general distribution on iTunes.
+You need a Mac computer with Xcode installed (Xcode is a free download), and you need the eight provisioning profiles (4 Ad Hoc and 4 Apple Store) and p12 file that you created copied to the same computer that you are using to upload your app to iTunes.
+You will also need a number of screenshots of your app in specific sizes and resolutions, which are detailed in your iTunes Connect setup screen.
 
-Now that you have created your branded Android app with ownCloud’s ownBuilder service (building_branded_android_client) how do you distribute it to your users? There are multiple ways: email, publish_server, or publish_google_play.
-However you distribute it, the first step is to digitally sign your new app.
-Signing your app verifies authorship and authenticity.
+TIP: Apple must review and approve your app, and the approval process can take several days to several weeks.
 
-When you create your branded Android app we supply you with two `.apk` files: one for debugging and testing, and one for deployment, like these examples:
+{owncloud-customer-url}[Download the `xcarchive.zip` file] from your account.
+Your friendly macOS computer will automatically unpack it and change the name to something like `ownCloud
+iOS Client 02-07-15 10.30.xcarchive`.
+Double-click on this file to automatically install it into Xcode.
+Go to Xcode and you will see it in the Archives listing under menu:Window[Organizer].
 
-[source]
-....
-acmecloud_2.0.0-debug.apk
-acmecloud_2.0.0-release-unsigned.apk
-....
+image:branded_ios_app/ios-publish-2.png[figure 1]
 
-The second `.apk` file, `acmecloud_2.0.0-release-unsigned.apk`, is the one you will sign and distribute.
+Next, go back to the https://developer.apple.com/membercenter/index.action[Apple Developer Member Center] to log into iTunes Connect to set up your app storefront.
 
-== Digitally Signing Android Apps
+image:branded_ios_app/ios-publish-3.png[figure 2]
 
-Signing your app is required.
-You can do this in the ownBrander
-wizard <sign_android_app>, or after it is built and delivered to you.
-The most time-consuming part of signing the built app is installing the commands you need to sign it.
-You need three commands to sign your app: `keytool`, `jarsigner`, and `zipalign`.
-Follow these steps:
-
-1.  Install the signing commands
-2.  Create a self-signed certificate with `keytool`
-3.  Use `jarsigner` to sign the app, and to verify signing
-4.  Use `zipalign` to optimize your app
-
-You only need to create a certificate once, and then use it to sign all of your branded ownCloud apps.
-If you publish your apps on Google Play they must all be signed with the same certificate.
-
-=== Installing the App Signing Tools
-
-`keytool` and `jarsigner` are in Java runtimes.
-Linux users can get these in OpenJDK.
-For example, on current versions of Debian, Mint, and Ubuntu Linux you need to install two packages.
-The first one supplies `keytool` and the second one supplies `jarsigner`:
-
-[source]
-....
-$ sudo apt-get install openjdk-7-jre-headless
-$ sudo apt-get install openjdk-7-jdk
-....
-
-Plus some additional 32-bit packages:
-
-[source]
-....
-$ sudo apt-get install libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5
-zlib1g:i386
-....
-
-On SUSE systems, install this package:
-
-[source]
-....
-$ sudo zypper install java-1_7_0-openjdk-devel
-....
-
-It is simpler to get these on CentOS and Red Hat Enterprise Linux, as they have created some nice wrapper scripts around `keytool` and `jarsigner` that you can install standalone:
-
-[source]
-....
-$ sudo yum install keytool-maven-plugin.noarch
-$ sudo yum install maven-jarsigner-plugin.noarch
-....
-
-Mac OS X and Windows users can download the Oracle JDK from http://www.oracle.com/technetwork/java/javase/downloads/index.html[Oracle’s Java Download] page.
-
-`zipalign` is included in the https://developer.android.com/sdk/index.html[Android Software Development Kit].
-It is a large download, but once you have downloaded it you can copy the `zipalign` binary to any computer and use it.
-Go to https://developer.android.com/sdk/index.html[Android Software Development Kit] and click the "Download Android Studio" button.
-
-image:branded_ios_app/android_custom_17.png[image]
-
-Download the appropriate *SDK Tools Only* package for your operating system.
-
-image:branded_ios_app/android_custom_18.png[image]
-
-Unpack it and change to the unpacked directory, which is `android-sdk-linux` on Linux systems, `android-sdk-macosx` on Mac systems, and `android-sdk-windows` on Windows systems.
-There is one more step, and that is to install additional tools.
-Run this command from the unpacked directory:
-
-[source]
-....
-tools/android update sdk --no-ui
-....
-
-This will take some time, as it is a large download.
-When it’s finished you’ll find `zipalign` in the `build-tools` directory.
-For convenience, you could copy `zipalign` to your home folder or other location of your choice, and to any other computer without installing the whole Android SDK.
-
-=== Digitally Signing Your App
-
-After installing your signing tools, signing your app takes just a few steps.
-In these examples the name of the app, as supplied by ownBuilder, is `acmecloud_1.7.0-release-unsigned.apk`.
-
-To create your certificate copy the following command, replacing `acme-release-key.keystore` and `acme_key` with your own keystore name and alias, which can be anything you want.
-The keystore name and alias must both have a password, which can be same for both.
-Then enter your company information as you are prompted:
-
-[source]
-....
-$ keytool -genkey -v -keystore acme-release-key.keystore -alias acme_key
--keyalg RSA -keysize 2048 -validity 10000
-Enter keystore password:
-Re-enter new password:
-What is your first and last name?
- [Unknown]:  Acme Boss
-What is the name of your organizational unit?
- [Unknown]:  Acme Headquarters
-What is the name of your organization?
- [Unknown]:  Acme, Inc.
-What is the name of your City or Locality?
- [Unknown]:  Anytown
-What is the name of your State or Province?
- [Unknown]:  CA
-What is the two-letter country code for this unit?
- [Unknown]:  US
-Is CN=Acme Boss, OU=Acme Headquarters, O="Acme, Inc.", L=Anytown, ST=CA, C=US
-correct?
- [no]:  yes
-
-Generating 2,048 bit RSA key pair and self-signed certificate (SHA256withRSA)
-with a validity of 10,000 days
-       for: CN=Acme Boss, OU=Acme Headquarters, O="Acme, Inc.", L=Anytown,
-       ST=CA, C=US
-Enter key password for <acme_key>
-       (RETURN if same as keystore password):
-[Storing acme-release-key.keystore]
-....
-
-Now use `jarsigner` to sign your app.
-Replace `acme-release-key.keystore` and `acme_key` with your own keystore name and alias:
-
-[source]
-....
-$ jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore
-acme-release-key.keystore acmecloud_1.7.0-release-unsigned.apk acme_key
-Enter Passphrase for keystore:
-  adding: META-INF/MANIFEST.MF
-  adding: META-INF/ACME_KEY.SF
-  adding: META-INF/ACME_KEY.RSA
- signing: res/anim/disappear.xml
- signing: res/anim/grow_from_bottom.xml
- [...]
- jar signed.
-
- Warning:
- No -tsa or -tsacert is provided and this jar is not timestamped.
-Without a
- timestamp, users may not be able to validate this jar after the signer
- certificate's expiration date (2042-07-28) or after any future revocation
- date.
-....
-
-You can ignore the warning at the end; you should see a `jar signed` message when it is finished.
-
-Now you can verify that your app is signed:
-
-[source]
-....
-$ jarsigner -verify -verbose -certs acmecloud_1.7.0-release-unsigned.apk
+After logging in click the blue btn:[My Apps] button.
+This takes you to the main screen for managing your apps on iTunes.
 
-     sm       943 Thu Mar 12 12:47:56 PDT 2015
-     res/drawable-mdpi/abs__dialog_full_holo_light.9.png
+image:branded_ios_app/ios-publish.png[figure 3]
 
-     X.509, CN=Acme Boss, OU=Acme Headquarters, O="Acme, Inc.", L=Anytown,
-     ST=CA, C=US
-....
+Click the plus button on the top left to setup your new branded iOS app.
 
-This will spit out hundreds of lines of output.
-If it ends with the following it’s good:
+image:branded_ios_app/ios-publish-4.png[figure 4]
 
-[source]
-....
-s = signature was verified
-m = entry is listed in manifest
-k = at least one certificate was found in keystore
-i = at least one certificate was found in identity scope
+This opens a screen where you will enter your app information.
+Make sure you get it right the first time, because it is difficult to delete apps, and Apple will not let you re-use your app name or SKU.
 
-jar verified.
-....
+* Enter any name you want for your app.
+  This is the name that will appear in your App Store listing.
+* Choose your primary language.
+* Select the bundle ID from the drop-down selector.
+* Enter your app version number, which should match the version number as it appears in your Xcode organizer.
+* The SKU is a unique ID for your app, and is anything you want.
 
-The last step for preparing your `.apk` for release is to run `zipalign` on it. `zipalign` optimizes your file to use less memory.
-You must specify both an input and an output file, so this is good time to give your app a shorter name, and it should not say "unsigned".
-Our example file will be renamed to `acmecloud_1.7.0.apk`:
+Then click the btn:[Create] button.
 
-[source]
-....
-$ zipalign -v 4 acmecloud_1.7.0-release-unsigned.apk acmecloud_1.7.0.apk
-Verifying alignment of acmecloud_1.7.0.apk (4)...
-     50 META-INF/MANIFEST.MF (OK - compressed)
-  13277 META-INF/ACME_KEY.SF (OK - compressed)
-  27035 META-INF/ACME_KEY.RSA (OK - compressed)
-  28206 res/anim/disappear.xml (OK - compressed)
-  [..]
-  Verification succesful
-....
+image:branded_ios_app/ios-publish-5.png[figure 5]
 
-Again, this emits a lot of output, and when you see *Verification succesful* at the end you know it succeeded, and it is ready to distribute.
+Now go back to your Xcode organizer to upload your app; click the blue btn:[Submit to App Store] button.
 
-== Distribution via Email
+image:branded_ios_app/ios-publish-6.png[figure 6]
 
-You can download your branded Android app from your account on https://customer.owncloud.com/owncloud[Customer.owncloud.com], and send it as an email attachment to your users. (This is not the optimal way to distribute it as it is over 2 megabytes in size.) When they open your email on their Android phone or tablet, they must first click the the download arrow (bottom right of the screenshot) to download your app.
+This takes a few minutes as it verifies your bundle ID and certificates, and then you will see an upload status.
 
-image:branded_ios_app/android_custom_1.png[image]
+image:branded_ios_app/ios-publish-7.png[figure 7]
 
-When the arrow changes to a green checkbox, it has been downloaded.
+At long last, after working through this long complex process, you are almost ready to publish your app on iTunes.
 
-image:branded_ios_app/android_custom_2.png[image]
+[[setting-up-your-itunes-storefront]]
+= Setting up Your iTunes Storefront
 
-Now your user must click on the green checkbox, and this launches the app installer, and all they have to do is follow the installation wizard to install your branded app.
+There are just a few steps remaining.
+Now that you have uploaded your branded iOS app, you need to upload some screenshots, an optional demo video, and fill in some information for your app listing on your iTunes storefront.
+You should see something like this on your main screen (figure 8).
+You should click the btn:[Save] button at the top right periodically to preserve your changes.
 
-image:branded_ios_app/android_custom_3.png[image]
+image:branded_ios_app/ios-publish-8.png[figure 8]
 
-When the installation is complete, the https://doc.owncloud.com/android/[ownCloud Android App Manual] contains instructions for using the app.
+This screen displays all of your apps and their submission status.
+Click btn:[Prepare for Submission] to get started on the submission process.
+The first screen is for entering screenshots of your app for various devices, and optionally a demonstration video. 
+Click the little question marks to learn the required image specifications.
 
-== Publish On Your ownCloud Server
+image:branded_ios_app/ios-publish-9.png[figure 9]
 
-You can distribute your branded app from your ownCloud server.
-Simply upload it to your ownCloud server and share it like any other file: you can create normal ownCloud shares with ownCloud users and groups, and you may create a link share to share it with anyone. (See the *Files & Synchronization* section of the https://doc.owncloud.org/server/9.0/user_manual/files/index.html[ownCloud User Manual] to learn more about sharing files.)
+Apple simplified {screenshot-submission-process-url}[the screenshot submission process]. 
+Please {screenshot-submission-process-video-url}[check this Video (in Safari)] for details. 
 
-== Publish to the Google Play Store
+For the ownCloud client, we also don't use real screenshots, we use {sized-frames-url}[frames in different sizes instead]. 
+You can find templates to generate those assets.
+Here are examples for the Sketch app:
 
-You may elect to publish your app in the Google Play store, either as a free or paid app.
-There are several steps to publishing a free app:
+* https://github.com/LaunchKit/SketchToAppStore
+* https://github.com/MengTo/AppStoreSketch
 
-1.  Create a Google Play Publisher account.
-2.  Sign your branded app with your own signing certificate.
-3.  Upload your signed branded app to your Google Play Publisher account.
+Then you must enter:
 
-As part of creating your Google Play Publisher account you will have to create some screenshots of your app in specific sizes, and create a store description.
+* Your app name 
+* A description 
+* Some keywords for iTunes searches; and 
+* Some optional URLs
 
-=== Create a Google Play Publisher Account
+image:branded_ios_app/ios-publish-10.png[figure 10]
 
-Start at Google’s http://developer.android.com/distribute/googleplay/start.html[Get Started With Publishing] page.
-Have a credit card ready, because it costs $25.
-If you already have a Google account, it is usually better to create a separate new account just for publishing apps to the Google Play Store.
+The next section is for Apple Watch.
+If you don't support Apple Watch you can skip this.
 
-Google’s process for uploading apps is fairly streamlined, and the most time-consuming task is creating all the required graphics.
-After registering, you’ll see the welcome screen for the Google Dev Console.
-Click *Publish an Android app on Google Play*.
+The *General App Information* section requires a:
 
-image:branded_ios_app/android_custom_6.png[image]
+* 1024 x 1024 logo 
+* Version 
+* Rating 
+* Category 
+* License 
+* Copyright, and 
+* Contact information
 
-This opens the *Add New Application* screen.
-Click the *Prepare Store Listing* button. (Note that as you navigate the various screens, you can click the Save Draft button to preserve your changes.)
+image:branded_ios_app/ios-publish-11.png[figure 11]
 
-image:branded_ios_app/android_custom_7.png[image]
+In the *Build* section, click the plus button and select your app.
 
-On the next screen, enter your product description.
+image:branded_ios_app/ios-publish-14.png[figure 12]
 
-image:branded_ios_app/android_custom_8.png[image]
+The *App Review Information* requires contact information, and some information about your app to guide reviewers.
+Remember, everyone on iTunes can review your app, so it's in your best interest to be helpful.
+You may optionally provide a login for a demo account.
 
-Then you’ll have to upload a batch of graphics in various sizes for the *Graphic Assets* section, like these images for a smartphone and seven-inch tablet.
-You are required to upload at least two images.
+image:branded_ios_app/ios-publish-12.png[figure 13]
 
-image:branded_ios_app/android_custom_9.png[image]
+The *Version Release* section allows you to choose between automatic release, which means your app will be published upon approval, or manual release, where you must release your app after it is approved.
 
-You must also upload a 512x512-pixel logo, and a 1024x500 banner.
+= Pricing
 
-image:branded_ios_app/android_custom_10.png[image]
+Next, you must go to the *Pricing* page to set your price, and to select the territories you want your app to be available in.
 
-Now choose the store categories for your app.
+image:branded_ios_app/ios-publish-13.png[figure 14]
 
-image:branded_ios_app/android_custom_11.png[image]
+= Submit For Review
 
-Then enter your contact information, which will be visible on your store listing.
+When you have filled in all the required forms and provided the required screenshots, click *Save* and then *Submit for Review*.
+If anything needs to be corrected you will see messages telling you exactly what must be fixed.
 
-image:branded_ios_app/android_custom_12.png[image]
+The next screen is legalese; click the appropriate Yes or No boxes, and then click the *Submit* button.
 
-On the next line you may optionally link to your privacy policy.
-It is recommended to have a privacy policy.
+You are now finished.
+No really, you are.
+When you return to your *My Apps* page you'll see that the status of your app has changed to "Waiting for review".
+In a few days, or perhaps many days, your app will either be approved or rejected.
+If it is rejected Apple will tell you what you need to do to get it approved.
 
-When you’re finished with the *Store Listing* page, go to the *Pricing and Distribution* page.
-You may make this a paid or free app.
-You cannot convert a free app to paid.
-You may convert a paid app to free, but then you can’t convert it back to paid.
-You’ll have numerous options for paid apps, such as Android Wear, Android TV, and various Google marketing tie-ins, and many more.
+= FAQ
 
-For now let’s make this a free app, so click the Free button and select the countries you want to distribute it in.
+xref:branded_ios_app/faq_ios_app_review_team.adoc[Here are the most common answers to questions] from the iOS App Review Team.
 
-image:branded_ios_app/android_custom_13.png[image]
+image:branded_ios_app/ios-publish-15.png[figure 15]
 
-Now you may upload your app.
-
-=== Uploading to Google Play Store
-
-Now you can upload your app to your Google Play Store page.
-Go to the *APK* page and click *Upload your first APK to Production*.
-You don’t need a license key for a free app.
-
-image:branded_ios_app/android_custom_14.png[image]
-
-Drag-and-drop, or browse to select your app.
-
-image:branded_ios_app/android_custom_15.png[image]
-
-A successful upload looks like this:
-
-image:branded_ios_app/android_custom_20.png[image]
-
-Your app is not yet published, but only uploaded to your account.
-There is one more step to take before you can publish, and that is to go back to the *Pricing & Distribution* page and fill out the *Consent* section.
-
-image:branded_ios_app/android_custom_21.png[image]
-
-Click the Save Draft button, and if you followed all the required steps you should now see a *Publish App* button.
-
-image:branded_ios_app/android_custom_22.png[image]
-
-It will not be published immediately, but after review by Google, which usually takes just a few hours.
-
-image:branded_ios_app/android_custom_23.png[image]
-
-After it has been published, your store listing is updated as PUBLISHED, and it includes a link to your Play Store listing.
-
-image:branded_ios_app/android_custom_24.png[image]
-
-Now all you need to do is distribute the URL to your users, and they can install it either from their Web browsers, or from their Google Play Store apps.
-This is how it looks to your users.
-
-image:branded_ios_app/android_custom_25.png[image]
-
-== Customize Download Link
-
-You may configure the URLs to your own download repositories for your ownCloud desktop clients and mobile apps in config/config.php.
-This example shows the default download locations:
-
-[source,sourceCode,php]
-----
-<?php
-
-  "customclient_desktop" => "https://owncloud.org/sync-clients/",
-  "customclient_android" =>
-  "https://play.google.com/store/apps/details?id=com.owncloud.android",
-  "customclient_ios"     =>
-  "https://itunes.apple.com/us/app/owncloud/id543672169?mt=8",
-----
-
-Simply replace the URLs with the links to your own preferred download repos.
-
-You may test alternate URLs without editing config/config.php by setting a test URL as an environment variable:
-
-[source]
-....
-export OCC_UPDATE_URL=https://test.example.com
-....
-
-When you’re finished testing you can disable the environment variable:
-
-[source]
-....
-unset OCC_UPDATE_URL
-....
-
-=== Publishing a Paid App in Google Play
-
-If you would rather not give your branded app away you can sell it on Google Play.
-You may convert a paid app to free, but you may not convert a free app to paid.
-
-You must establish a Google Wallet Merchant Account.
-On your Google Dev Console click the *Learn more* link under the Free/Paid button for a nice thorough review of the process and tools.
-It requires verifying your business information and bank account, and you should expect it to take 3-4 days.
-
-image:branded_ios_app/android_custom_26.png[image]
-
-When you’re ready to set it up, click the *Set up a merchant account now* link under the Free/Paid button.
-
-== Resources
-
-* http://developer.android.com/distribute/googleplay/start.html[Get Started With Publishing]
-* https://developer.android.com/tools/publishing/app-signing.html#signing-manually[Signing Your App Manually]
-* http://developer.android.com/distribute/googleplay/developer-console.html[Developer Console]
+When, at last, it is published on iTunes you may distribute the URL so that your users may install and use your app.


### PR DESCRIPTION
This fixes https://github.com/owncloud/docs/issues/539, which showed that the documentation for publishing a branded Android app had overwritten the documentation for publishing a branded iOS app.