### PR TITLE
Customise the way that auto-generated anchors are created

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -14,3 +14,12 @@ ui:
 output:
   clean: true
   dir: public
+
+asciidoc:
+  attributes:
+    # The following two global attributes:
+    # 1. Remove the auto-generated anchor id prefix
+    # 2. Replace the auto-generated anchor id separator
+    # For more information, see https://asciidoctor.org/docs/user-manual/#auto-generated-ids
+    idprefix: ''
+    idseparator: '-'


### PR DESCRIPTION
This PR copies https://github.com/owncloud/docs/commit/5b3d97bb9e61c763ad2f265d0537b7999345b9a0, which removes the auto-generated anchor prefix and changes the separator to a hyphen. This will help to keep all the ownCloud documentation repositories consistent.