### PR TITLE
Add TOC, some text fixes and rendering improvements

### DIFF
--- a/modules/ROOT/pages/branded_android_app/building_branded_android_client.adoc
+++ b/modules/ROOT/pages/branded_android_app/building_branded_android_client.adoc
@@ -1,4 +1,7 @@
 = Building Your App With ownBrander
+:toc: right
+
+== Introduction
 
 Building an Android app requires just a few images, and the wizard tells you their required dimensions.
 They must be the exact specified dimensions, preferably in PNG format.
@@ -48,7 +51,7 @@ You can upload your signing certificate in the wizard so that is signed during t
 See publishing_android_app to learn how to sign your app after it is built.
 
 Google Play Store requires that certificates have a validity period ending after October 22, 2033.
-See link:[<http://developer.android.com/intl/es/tools/publishing/app-signing. html#considerations>].
+See http://developer.android.com/intl/es/tools/publishing/app-signing.html#considerations
 
 *Root folder name* displays the root folder name on your user’s devices.
 

--- a/modules/ROOT/pages/branded_android_app/publishing_android_app.adoc
+++ b/modules/ROOT/pages/branded_android_app/publishing_android_app.adoc
@@ -1,4 +1,7 @@
 = Distributing Your Branded Android App
+:toc: right
+
+== Introduction
 
 Now that you have created your branded Android app with ownCloud’s ownBuilder service (building_branded_android_client) how do you distribute it to your users? There are multiple ways: email, publish_server, or publish_google_play.
 However you distribute it, the first step is to digitally sign your new app.
@@ -204,7 +207,7 @@ Again, this emits a lot of output, and when you see *Verification succesful* at 
 
 == Distribution via Email
 
-You can download your branded Android app from your account on https://customer.owncloud.com/owncloud[Customer.owncloud.com], and send it as an email attachment to your users. (This is not the optimal way to distribute it as it is over 2 megabytes in size.) When they open your email on their Android phone or tablet, they must first click the the download arrow (bottom right of the screenshot) to download your app.
+You can download your branded Android app from your account on https://customer.owncloud.com/owncloud[customer.owncloud.com], and send it as an email attachment to your users. (This is not the optimal way to distribute it as it is over 2 megabytes in size.) When they open your email on their Android phone or tablet, they must first click the the download arrow (bottom right of the screenshot) to download your app.
 
 image:branded_android_app/android_custom_1.png[image]
 
@@ -221,7 +224,7 @@ When the installation is complete, the https://doc.owncloud.com/android/[ownClou
 == Publish On Your ownCloud Server
 
 You can distribute your branded app from your ownCloud server.
-Simply upload it to your ownCloud server and share it like any other file: you can create normal ownCloud shares with ownCloud users and groups, and you may create a link share to share it with anyone. (See the *Files & Synchronization* section of the https://doc.owncloud.org/server/9.0/user_manual/files/index.html[ownCloud User Manual] to learn more about sharing files.)
+Simply upload it to your ownCloud server and share it like any other file: you can create normal ownCloud shares with ownCloud users and groups, and you may create a link share to share it with anyone. (See the *Files & Synchronization* section of the https://doc.owncloud.org/server/latest/user_manual/files/index.html[ownCloud User Manual] to learn more about sharing files.)
 
 == Publish to the Google Play Store
 

--- a/modules/ROOT/pages/branded_desktop_client/update_branded_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/update_branded_desktop_clients.adoc
@@ -1,5 +1,7 @@
 = Updating Your Branded Desktop Clients
+:toc: right
 
+== Introduction
 
 The Client Updater Server provides a Web service that will tell an ownCloud desktop sync client whether or not an update is available.
 If an update is available, it will also provide metadata for the update, such as the Download URL, signatures or a fallback URL that the client can resort to in case the update goes wrong.
@@ -18,26 +20,24 @@ See the examples below to learn how to do this.
 == Prerequisites
 
 1.  Configure "Update URL" in the "Desktop" section of your ownBrander account (available for "advanced" users only).
-* Example:::
-  https://mycloud.example.com/updates/ (note the forward slash at the end.)
+* Example: +
+  `\https://mycloud.example.com/updates/` (note the forward slash at the end.)
 2.  Generate branded clients.
 3.  Upload branded clients to your Web server.
-* Windows example:::
-  https://mycloud.example.com/install/mycloud-2.1.1.240-setup.exe
-* Mac OS X examples:::
-  https://mycloud.example.com/install/mycloud-2.1.1.787.pkg
-  +
-  https://mycloud.example.com/install/mycloud-2.1.1.787.pkg.tbz
-  +
-  https://mycloud.example.com/install/mycloud-2.1.1.787.pkg.tbz.sig
+* Windows example: +
+  `\https://mycloud.example.com/install/mycloud-2.1.1.240-setup.exe`
+* Mac OS X examples: +
+  `\https://mycloud.example.com/install/mycloud-2.1.1.787.pkg` +
+  `\https://mycloud.example.com/install/mycloud-2.1.1.787.pkg.tbz` +
+  `\https://mycloud.example.com/install/mycloud-2.1.1.787.pkg.tbz.sig`
 * You should have a Web page with links to your branded clients, so your users can find and download them.
-For example, https://mycloud.example.com/install/ with `Options +Indexes` in your ownCloud `.htaccess` file.
+For example, `\https://mycloud.example.com/install/` with `Options +Indexes` in your ownCloud `.htaccess` file.
 
 == Install client-updater-server
 
 1.  Download `client-updater-server-0.4.tar.xz` from https://customer.owncloud.com/.
 2.  Extract `client-updater-server-0.4.tar.xz` to your Web server.
-The `index.php` must be accessible at `https://mycloud.example.com/updates/index.php`.
+The `index.php` must be accessible at `\https://mycloud.example.com/updates/index.php`.
 3.  Copy your ownCloud `config/ownCloud.yml` file, and name it according your *Application short name* as configured in ownBrander.
 +
 Example: `config/mycloud.yml`
@@ -152,7 +152,8 @@ Name of the new client, same as "Application name" configured in ownBrander.
 
 === Windows
 
-This a example URL of a 2.1.1 client for Mac OS X: https://mycloud.example.com/updates/?version=2.1.1.140&platform=win32&oem= mycloud
+This a example URL of a 2.1.1 client for Mac OS X: +
+`\https://mycloud.example.com/updates/?version=2.1.1.140&platform=win32&oem= mycloud`
 
 You should see something like the following in your Web server logs:
 
@@ -182,11 +183,7 @@ The output should look like this if you call the URL manually:
 
 This a example URL of a 2.1.1 client for Mac OS X:
 
-[source]
-....
-https://mycloud.example.com/updates/?version=2.1.1.687&platform=macos&oem=
-mycloud&sparkle=true
-....
+`\https://mycloud.example.com/updates/?version=2.1.1.687&platform=macos&oem=mycloud&sparkle=true`
 
 You should see something like the following in your Web server logs:
 

--- a/modules/ROOT/pages/branded_ios_app/faq_ios_app_review_team.adoc
+++ b/modules/ROOT/pages/branded_ios_app/faq_ios_app_review_team.adoc
@@ -1,5 +1,5 @@
 = FAQ iOS App Review Team
-
+:toc: right
 
 Information from Apple: https://developer.apple.com/support/app-review/
 

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app.adoc
@@ -1,4 +1,7 @@
 = Building and Distributing Your Branded iOS App
+:toc: right
+
+== Introduction
 
 Building and distributing your branded iOS ownCloud app involves a large number of interdependent steps.
 The process is detailed in this chapter over several pages.
@@ -9,22 +12,22 @@ Follow these instructions exactly and in order, and you will have a nice branded
 * A Mac OS X computer with Xcode (free download) and Keychain Access (included in Utilities).
 This computer is essential to the entire process and will be linked to to your iOS Developer account.
 You will use it create and store distribution certificates, and to upload your app to iTunes Connect.
-* An iOS developer account on https://developer.apple.com/ios/[Developer.Apple.com/ios], which costs $99 per year.
+* An iOS developer account on https://developer.apple.com/ios/[developer.apple.com/ios], which costs $99 per year.
 Or an Enterprise account for $299/yr.
 The developer account limits you to testing on 100 devices of each type (Apple TV, Apple Watch, iPad, iPhone, iPod Touch) which must be registered in your account.
 The Enterprise account allows testing on unlimited, unregistered devices.
-* An ownCloud Enterprise Subscription, with the ownBrander app enabled on https://customer.owncloud.com/owncloud[Customer.owncloud.com]
+* An ownCloud Enterprise Subscription, with the ownBrander app enabled on https://customer.owncloud.com/owncloud[customer.owncloud.com]
 * Some iPhones or iPads for testing your app.
-Again, if you have the $99 developer account each device must have its UDID registered in your account on https://developer.apple.com[Developer.Apple.com].
+Again, if you have the $99 developer account each device must have its UDID registered in your account on https://developer.apple.com[developer.apple.com].
 
 == Procedure
 
 You need the Apple tools to build eight provisioning profiles (4 Ad Hoc and 4 App Store) and a P12 certificate.
-You will email the four Ad Hoc profiles and P12 certificate to support@owncloud.com after building your app with the ownBrander app on https://customer.owncloud.com/owncloud[Customer.owncloud.com].
+You will email the four Ad Hoc profiles and P12 certificate to support@owncloud.com after building your app with the ownBrander app on https://customer.owncloud.com/owncloud[customer.owncloud.com].
 You must create the provisioning profiles and P12 certificate first, before building your app, because you must supply a unique *bundle ID* and an *app group* to build your app.
-These are created in your account on https://developer.apple.com[Developer.Apple.com], and with Keychain Access on your Mac computer.
+These are created in your account on https://developer.apple.com[developer.apple.com], and with Keychain Access on your Mac computer.
 
-We use the 4 Ad Hoc provisioning profiles and P12 certificate to complete building your app, and then in 24-48 hours your new branded app is loaded into your account on https://customer.owncloud.com/owncloud[Customer.owncloud.com].
+We use the 4 Ad Hoc provisioning profiles and P12 certificate to complete building your app, and then in 24-48 hours your new branded app is loaded into your account on https://customer.owncloud.com/owncloud[customer.owncloud.com].
 
 The next step is to test your app.
 When it passes testing, the final step is to upload it to your iTunes Connect account for distribution.

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_2.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_2.adoc
@@ -1,5 +1,5 @@
 = Create Certificate Signing Request
-
+:experimental:
 
 Start by creating a .certSigningRequest (CSR) file on your Mac, using Keychain Access.
 Open Finder, and then open Keychain Access from the Utilities folder.
@@ -12,21 +12,21 @@ image:branded_ios_app/mac-2.png[image]
 
 Enter the email address that you use in your Apple developer account, and enter a common name.
 The common name can be anything you want, for example a helpful descriptive name like "ios-mybiz".
-Check *Saved to disk* and *Let me specify key pair information*, then click *Continue*.
+Check *Saved to disk* and *Let me specify key pair information*, then click btn:[Continue].
 
 image:branded_ios_app/mac-3.png[image]
 
-Give your CSR a helpful descriptive name, such as *iosapp.certSigningRequest*, and choose the location to save it on your hard drive, then click *Save*.
+Give your CSR a helpful descriptive name, such as *iosapp.certSigningRequest*, and choose the location to save it on your hard drive, then click btn:[Save].
 
 image:branded_ios_app/mac-4.png[image]
 
-In the next window, set the *Key Size* value to *2048 bits* and *Algorithm* to *RSA*, and click *Continue*.
+In the next window, set the *Key Size* value to *2048 bits* and *Algorithm* to *RSA*, and click btn:[Continue].
 This will create and save your certSigningRequest file (CSR) to your hard drive.
 
 image:branded_ios_app/mac-5.png[image]
 
 In the next screen your certificate creation is verified.
-Click a button to view it, or click *Done* to go to the next step.
+Click a button to view it, or click btn:[Done] to go to the next step.
 
 image:branded_ios_app/mac-6.png[image]
 
@@ -40,7 +40,7 @@ Check *Allow all applications to access this item*.
 image:branded_ios_app/mac-8.png[image]
 
 Now login to the *Member Center* on https://developer.apple.com/.
-Click *Certificates, Identifiers, & Profiles*.
+Click btn:[Certificates, Identifiers, & Profiles].
 
 image:branded_ios_app/cert-1.png[image]
 
@@ -48,16 +48,16 @@ Then click *iOS Apps > Certificates*.
 
 image:branded_ios_app/cert-2.png[image]
 
-Next, click the add button (the little plus sign) in the top right corner of the *iOS Certificate* page.
+Next, click the btn:[add button] (the little plus sign) in the top right corner of the *iOS Certificate* page.
 
 image:branded_ios_app/cert-3.png[image]
 
-Under "What type of certificate do you need?" check *App Store and Ad Hoc*, then click the *Continue* button at the bottom of the page.
+Under "What type of certificate do you need?" check *App Store and Ad Hoc*, then click the btn:[Continue] button at the bottom of the page.
 
 image:branded_ios_app/cert-4.png[image]
 
 The next screen, *About Creating a Certificate Signing Request (CSR)* has information about creating a CSR in Keychain Access.
-You already did this, so go to the next screen. "Add iOS Certificate", to upload the CSR you already created, then click the *Generate* button.
+You already did this, so go to the next screen. "Add iOS Certificate", to upload the CSR you already created, then click the btn:[Generate] button.
 
 image:branded_ios_app/cert-5.png[image]
 

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_3.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_3.adoc
@@ -1,15 +1,18 @@
 = Create Bundle IDs
+:toc: right
+:experimental:
 
+== Create Bundle IDs
 
 The next step is to create four *Bundle IDs*.
 These are unique identifiers for your branded iOS app.
 You must also create an *App Group* and place your three *Bundle IDs* in your *App Group*.
-You will need your base *Bundle ID* and *App Group* when you build your app with the ownBrander app on https://customer.owncloud.com/owncloud[Customer.owncloud.com].
+You will need your base *Bundle ID* and *App Group* when you build your app with the ownBrander app on https://customer.owncloud.com/owncloud[customer.owncloud.com].
 
 == Create App ID
 
 Now you must create your App ID.
-Go to *Identifiers > App IDs* and click the plus button (top right) to open the "Register iOS App ID" screen.
+Go to *Identifiers > App IDs* and click the btn:[plus button] (top right) to open the "Register iOS App ID" screen.
 Fill in your *App ID Description*, which is anything you want, so make it helpful and descriptive.
 The *App ID Prefix* is your Apple Developer Team ID, and is automatically entered for you.
 
@@ -24,144 +27,144 @@ image:branded_ios_app/cert-9.png[image]
 
 The next section, *App Services*, is where you select the services you want enabled in your app.
 You can edit this anytime after you finish creating your *App ID*.
-Check *App Groups*, make your other selections and then click the *Continue* button at the bottom.
+Check *App Groups*, make your other selections and then click the btn:[Continue] button at the bottom.
 Now you can confirm all of your information.
-If everything is correct click *Submit*; if you need to make changes use the *Back* button.
+If everything is correct click btn:[Submit]; if you need to make changes use the btn:[Back] button.
 
 image:branded_ios_app/cert-11.png[image]
 
 When you are finished you will see a confirmation.
-Click the *Done* button at the bottom.
+Click the btn:[Done] button at the bottom.
 
 image:branded_ios_app/cert-12.png[image]
 
 == Create App Group
 
 The next step is to create an App Group and put your App ID in it.
-Go to *Identifiers > App Groups* and click the plus button (top right).
+Go to *Identifiers > App Groups* and click the btn:[plus button] (top right).
 
 image:branded_ios_app/cert-13.png[image]
 
 Create a description for your app group, and a unique identifier in the format _group.com.MyCompany.MyAppGroup_.
-Then click *Continue*
+Then click btn:[Continue]
 
 image:branded_ios_app/cert-14.png[image]
 
-Review the confirmation screen, and if everything looks correct click the *Register* button.
+Review the confirmation screen, and if everything looks correct click the btn:[Register] button.
 
 image:branded_ios_app/cert-15.png[image]
 
-You’ll see a final confirmation screen; click *Done*.
+You’ll see a final confirmation screen; click btn:[Done].
 
 image:branded_ios_app/cert-16.png[image]
 
-When you click on *App Groups* you will see your new app group.
+When you click on btn:[App Groups] you will see your new app group.
 
 image:branded_ios_app/cert-17.png[image]
 
-Now go back to *Identifiers > App IDs* and click on your App ID.
+Now go back to *Identifiers > App IDs* and click on your btn:[App ID].
 This opens a screen that displays all your app information.
-Click the *Edit* button at the bottom.
+Click the btn:[Edit] button at the bottom.
 
 image:branded_ios_app/cert-18.png[image]
 
-Click the *Edit* button next to *App Groups*.
+Click the btn:[Edit] button next to btn:[App Groups].
 
 image:branded_ios_app/cert-19.png[image]
 
-Check your app and click the *Continue* button.
+Check your app and click the btn:[Continue] button.
 
 image:branded_ios_app/cert-20.png[image]
 
 The next screen asks you to "Review and confirm the App Groups you have selected".
-Click the *Assign* button to confirm.
-The next screen announces "You have successfully updated the App Groups associations with your App ID", and you must click yet another button, the *Done* button at the bottom.
+Click the btn:[Assign] button to confirm.
+The next screen announces "You have successfully updated the App Groups associations with your App ID", and you must click yet another button, the btn:[Done] button at the bottom.
 
 == Create a DocumentProvider Bundle ID
 
-Now you must return to *Identifiers > App IDs* and click the plus button to create a DocumentProvider Bundle ID.
-Follow the same naming conventions as for your App ID, then click *Continue*.
+Now you must return to *Identifiers > App IDs* and click the btn:[plus button] to create a DocumentProvider Bundle ID.
+Follow the same naming conventions as for your App ID, then click btn:[Continue].
 
 image:branded_ios_app/cert-25.png[image]
 
-Confirm your new App ID and click *Submit*.
+Confirm your new App ID and click btn:[Submit].
 
 image:branded_ios_app/cert-26.png[image]
 
 You will see one more confirmation: "Registration complete.
-This App ID is now registered to your account and can be used in your provisioning profiles." Click *Done*.
+This App ID is now registered to your account and can be used in your provisioning profiles." Click btn:[Done].
 
 Now you need to add it to your App Group.
-Go to *Identifiers > App IDs* and click on your new DocumentProvider Bundle ID to open its configuration window, and then click the *Edit* button at the bottom.
+Go to *Identifiers > App IDs* and click on your new btn:[DocumentProvider Bundle ID] to open its configuration window, and then click the btn:[Edit] button at the bottom.
 
 image:branded_ios_app/cert-27.png[image]
 
-Select *App Groups* and click the *Edit* button.
+Select btn:[App Groups] and click the btn:[Edit button].
 
 image:branded_ios_app/cert-28.png[image]
 
-Select your group and click *Continue*.
+Select your group and click btn:[Continue].
 
 image:branded_ios_app/cert-29.png[image]
 
 Once again you will asked if you really mean it.
-On the confirmation screen click *Assign*, and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
+On the confirmation screen click btn:[Assign], and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
 
 == Create a DocumentProviderFileProvider Bundle ID
 
-One more time, go to *Identifiers > App IDs* and click the plus button to create a DocumentProviderFileProvider Bundle ID.
-Follow the same naming conventions as for your App ID, then click *Continue*.
+One more time, go to *Identifiers > App IDs* and click the btn:[plus button] to create a DocumentProviderFileProvider Bundle ID.
+Follow the same naming conventions as for your App ID, then click btn:[Continue].
 
 image:branded_ios_app/cert-30.png[image]
 
-Confirm your new App ID and click *Submit*.
+Confirm your new App ID and click btn:[Submit].
 
 image:branded_ios_app/cert-31.png[image]
 
-You will see one more confirmation; review it and click *Done*.
+You will see one more confirmation; review it and click btn:[Done].
 Now you need to add it to your App Group.
-Go to *Identifiers > App IDs* and click on your new DocumentProviderFileProvider Bundle ID to open its configuration window, and then click the *Edit* button.
+Go to *Identifiers > App IDs* and click on your new btn:[DocumentProviderFileProvider Bundle ID] to open its configuration window, and then click the btn:[Edit] button.
 
 image:branded_ios_app/cert-32.png[image]
 
-Select *App Groups* and click the *Edit* button.
+Select btn:[App Groups] and click the btn:[Edit] button.
 
 image:branded_ios_app/cert-33.png[image]
 
-Select your group and click *Continue*.
+Select your group and click btn:[Continue].
 
 image:branded_ios_app/cert-34.png[image]
 
-On the confirmation screen click *Assign*, and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
+On the confirmation screen click btn:[Assign], and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
 
 == Create a ShareExtApp Bundle ID
 
 This supports Apple’s ShareIN extension.
 
-Yet again, go to *Identifiers > App IDs* and click the plus button to create a ShareExtApp Bundle ID.
-Follow the same naming conventions as for your App ID, then click *Continue*.
+Yet again, go to *Identifiers > App IDs* and click the btn:[plus button] to create a ShareExtApp Bundle ID.
+Follow the same naming conventions as for your App ID, then click btn:[Continue].
 
 image:branded_ios_app/cert-53.png[image]
 
-Confirm your new App ID and click *Submit*.
+Confirm your new App ID and click btn:[Submit].
 
 image:branded_ios_app/cert-54.png[image]
 
-You will see one more confirmation; review it and click *Done*.
+You will see one more confirmation; review it and click btn:[Done].
 Now you need to add it to your App Group.
-Go to *Identifiers > App IDs* and click on your new ShareExtApp Bundle ID to open its configuration window, and then click the *Edit* button.
+Go to *Identifiers > App IDs* and click on your new btn:[ShareExtApp Bundle ID] to open its configuration window, and then click the btn:[Edit] button.
 
 image:branded_ios_app/cert-55.png[image]
 
-Select *App Groups* and click the *Edit* button.
+Select btn:[App Groups] and click the btn:[Edit] button.
 
 image:branded_ios_app/cert-56.png[image]
 
-Select your group and click *Continue*.
+Select your group and click btn:[Continue].
 
 image:branded_ios_app/cert-57.png[image]
 
-On the confirmation screen click *Assign*, and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
+On the confirmation screen click btn:[Assign], and you’ll see the message "You have successfully updated the App Groups associations with your App ID."
 
 == Four Completed App IDs
 

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_5.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_5.adoc
@@ -1,29 +1,32 @@
 = Create Provisioning Profiles
+:toc: right
+:experimental:
 
+== Next Step
 
 The next phase of this glorious journey is to create eight provisioning profiles: 4 Ad Hoc and 4 App Store <app_store_profiles_label>.
-You will email the four Ad Hoc profiles, and your P12 certificate <publishing_ios_app_6> (which you will create after your provisioning profiles), to support@owncloud.com after building your branded app with the ownBrander app on https://customer.owncloud.com/owncloud[Customer.owncloud.com]. *Do not send us the App Store profiles.* All eight of these profiles must be stored on your Mac PC.
+You will email the four Ad Hoc profiles, and your P12 certificate <publishing_ios_app_6> (which you will create after your provisioning profiles), to support@owncloud.com after building your branded app with the ownBrander app on https://customer.owncloud.com/owncloud[customer.owncloud.com]. *Do not send us the App Store profiles.* All eight of these profiles must be stored on your Mac PC.
 
 == First Ad Hoc Provisioning Profile
 
-Go to *Provisioning Profiles > All*, then click the plus button (top right) to open the _Add iOS Provisioning Profile_ screen.
-Select *Ad Hoc* and click *Continue*.
+Go to *Provisioning Profiles > All*, then click the btn:[plus button] (top right) to open the _Add iOS Provisioning Profile_ screen.
+Select btn:[Ad Hoc] and click btn:[Continue].
 
 image:branded_ios_app/cert-35.png[image]
 
-On the *Select App ID* screen select the first of the three App IDs that you created and click *Continue*. (The first one has the shortest name, if you followed the naming conventions in this manual.)
+On the *Select App ID* screen select the first of the three App IDs that you created and click btn:[Continue]. (The first one has the shortest name, if you followed the naming conventions in this manual.)
 
 image:branded_ios_app/cert-36.png[image]
 
-Select the certificate that you created at the beginning of this process and click *Continue*.
+Select the certificate that you created at the beginning of this process and click btn:[Continue].
 
 image:branded_ios_app/cert-38.png[image]
 
-Select the devices that you want to install and test your app on, then click *Continue*.
+Select the devices that you want to install and test your app on, then click btn:[Continue].
 
 image:branded_ios_app/cert-39.png[image]
 
-Name your provisioning profile with a descriptive *Profile Name* and click *Generate*.
+Name your provisioning profile with a descriptive *Profile Name* and click btn:[Generate].
 
 image:branded_ios_app/cert-40.png[image]
 
@@ -37,25 +40,25 @@ image:branded_ios_app/cert-41.png[image]
 
 == Second Ad Hoc Provisioning Profile
 
-Return to the "Your provision profile is ready" screen, scroll to the bottom and click *Add Another*.
-On the following screen select *Ad Hoc* and click *Continue*.
+Return to the "Your provision profile is ready" screen, scroll to the bottom and click btn:[Add Another].
+On the following screen select btn:[Ad Hoc] and click btn:[Continue].
 
 image:branded_ios_app/cert-35.png[image]
 
-This time select the *.DocumentProvider* app ID and click *Continue*.
+This time select the *.DocumentProvider* app ID and click btn:[Continue].
 
 image:branded_ios_app/cert-42.png[image]
 
-Select the certificate that you created at the beginning of this process and click *Continue*.
+Select the certificate that you created at the beginning of this process and click btn:[Continue].
 
 image:branded_ios_app/cert-43.png[image]
 
-Select the devices that you want to install and test your app on, then click *Continue*.
+Select the devices that you want to install and test your app on, then click btn:[Continue].
 These must be the same devices you selected for the first provisioning profile.
 
 image:branded_ios_app/cert-39.png[image]
 
-Give this provisioning profile the same name as your first profile, plus *.DocumentProvider* and click *Generate*.
+Give this provisioning profile the same name as your first profile, plus *.DocumentProvider* and click btn:[Generate].
 
 image:branded_ios_app/cert-44.png[image]
 
@@ -63,8 +66,8 @@ Just like the first provisioning profile, download it to your Mac computer, and 
 
 == Third Ad Hoc Provisioning Profile
 
-Return to the "Your provision profile is ready" screen, scroll to the bottom and click *Add Another*.
-On the following screen select *Ad Hoc* and click *Continue*.
+Return to the "Your provision profile is ready" screen, scroll to the bottom and click btn:[Add Another].
+On the following screen select btn:[Ad Hoc] and click btn:[Continue].
 
 image:branded_ios_app/cert-35.png[image]
 
@@ -72,16 +75,16 @@ This time select the *.DocumentProviderFileProvider* app ID and click *Continue*
 
 image:branded_ios_app/cert-60.png[image]
 
-Select the certificate that you created at the beginning of this process and click *Continue*.
+Select the certificate that you created at the beginning of this process and click btn:[Continue].
 
 image:branded_ios_app/cert-43.png[image]
 
-Select the devices that you want to install and test your app on, then click *Continue*.
+Select the devices that you want to install and test your app on, then click [btn:[Continue].
 These must be the same devices you selected for the first provisioning profile.
 
 image:branded_ios_app/cert-39.png[image]
 
-Give this provisioning profile the same name as your first profile plus *.DocumentProviderFileProvider* and click *Generate*.
+Give this provisioning profile the same name as your first profile plus *.DocumentProviderFileProvider* and click btn:[Generate].
 There is a 50-character limit, but don’t worry about counting characters because it will be automatically truncated if you go over.
 
 image:branded_ios_app/cert-47.png[image]
@@ -90,25 +93,25 @@ Download it to your Mac computer, and then double-click to install it in Xcode.
 
 == Fourth Ad Hoc Provisioning Profile
 
-Return to the "Your provision profile is ready" screen, scroll to the bottom and click *Add Another*.
-On the following screen select *Ad Hoc* and click *Continue*.
+Return to the "Your provision profile is ready" screen, scroll to the bottom and click btn:[Add Another].
+On the following screen select btn:[Ad Hoc] and click btn:[Continue].
 
 image:branded_ios_app/cert-35.png[image]
 
-This time select the *.ShareExtApp* app ID and click *Continue*.
+This time select the *.ShareExtApp* app ID and click btn:[Continue].
 
 image:branded_ios_app/cert-46.png[image]
 
-Select the certificate that you created at the beginning of this process and click *Continue*.
+Select the certificate that you created at the beginning of this process and click btn:[Continue].
 
 image:branded_ios_app/cert-43.png[image]
 
-Select the devices that you want to install and test your app on, then click *Continue*.
+Select the devices that you want to install and test your app on, then click btn:[Continue].
 These must be the same devices you selected for the first provisioning profile.
 
 image:branded_ios_app/cert-39.png[image]
 
-Give this provisioning profile the same name as your first profile plus *.ShareExtApp* and click *Generate*.
+Give this provisioning profile the same name as your first profile plus *.ShareExtApp* and click btn:[Generate].
 There is a 50-character limit, but don’t worry about counting characters because it will be automatically truncated if you go over.
 
 image:branded_ios_app/cert-58.png[image]

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_7.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_7.adoc
@@ -1,12 +1,15 @@
 = Building Your iOS App With ownBrander
+:toc: right
+:experimental:
 
+== Build Your Branded iOS App
 
 At long last you have arrived at the point where you can actually build your branded iOS app.
-Log into your account on https://customer.owncloud.com/owncloud/[Customer.owncloud.com/owncloud] and open the ownBrander app.
+Log into your account on https://customer.owncloud.com/owncloud/[customer.owncloud.com/owncloud] and open the ownBrander app.
 
 image:branded_ios_app/ownbrander-1.png[image]
 
-If you don’t see the ownBrander app, open a support request (*Open Case* button).
+If you don’t see the ownBrander app, open a support request with the btn:[Open Case] button.
 
 Your first ownBrander task is to review the iOS page on ownBrander for your image requirements.
 You will need a lot of them, in specific sizes and formats, and they’re all listed on the ownBrander page.
@@ -35,7 +38,7 @@ Check *Server URL Visible* to make your ownCloud server URL the default, and to 
 image:branded_ios_app/ownbrander-16.png[image]
 
 And now, the all-important *Bundle ID*.
-Make sure that this is exactly the same as the *Bundle ID* you created on https://developer.apple.com[Developer.apple.com] (see publishing_ios_app_3).
+Make sure that this is exactly the same as the *Bundle ID* you created on https://developer.apple.com[developer.apple.com] (see xref:branded_ios_app/publishing_ios_app_3.adoc[Bundle ID]).
 
 image:branded_ios_app/ownbrander-17.png[image]
 
@@ -139,4 +142,4 @@ image:branded_ios_app/ownbrander-28.png[image]
 
 You may go back and make changes, and when you click the *Generate iOS App* button the build system will use your latest changes.
 
-Check your account on https://customer.owncloud.com/owncloud/[Customer.owncloud.com] in 48 hours to see your new branded ownCloud app.
+Check your account on https://customer.owncloud.com/owncloud/[customer.owncloud.com] in 48 hours to see your new branded ownCloud app.

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_8.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_8.adoc
@@ -1,18 +1,19 @@
 = Testing Your New Branded iOS App
+:toc: right
+:experimental:
 
+== Distribute the File
 
 You’ll distribute the file with the .ipa extension, like our example MyBiz iOS App-3.4.211.ipa, from your https://customer.owncloud.com/owncloud account to your beta testers.
 To do this you’ll need a Mac computer, an iPhone or iPad registered in your Apple developer account, and the iTunes account associated with your Apple developer account.
 
 1.  Connect your registered iPhone or iPad to a Mac running iTunes.
 2.  Double-click your iOS .ipa file.
-3.  You should see your device in the upper left corner of your iTunes windows.
-Click on it.
-4.  Click the Apps button.
-Now you should see your app in the iTune apps list, with an Install button.
-Click it.
+3.  You should see your device in the upper left corner of your iTunes windows. Click on it.
+4.  Click the btn:[Apps] button.
+Now you should see your app in the iTune apps list, with an Install button. Click it.
 5.  The Install button changes to Will Install.
-6.  Click the sync button in the lower-right corner to sync your device.
+6.  Click the btn:[sync button] in the lower-right corner to sync your device.
 This installs your app on your device.
 
 Your other testers can now install and test your app on their registered iPhones and iPads just like any other app from iTunes.

--- a/modules/ROOT/pages/branded_ios_app/publishing_ios_app_9.adoc
+++ b/modules/ROOT/pages/branded_ios_app/publishing_ios_app_9.adoc
@@ -1,9 +1,12 @@
 = Publishing Your New Branded iOS App
+:toc: right
 :experimental:
 :screenshot-submission-process-url: https://developer.apple.com/news/?id=08082016a
 :screenshot-submission-process-video-url: https://developer.apple.com/videos/play/wwdc2016/305/?time=1700
 :sized-frames-url: https://itunes.apple.com/app/owncloud/id543672169
 :owncloud-customer-url: https://customer.owncloud.com/owncloud
+
+== Publish for General Distribution on iTunes
 
 At last, after following all the previous steps and passing beta testing, your branded iOS app is ready to publish for general distribution on iTunes.
 You need a Mac computer with Xcode installed (Xcode is a free download), and you need the eight provisioning profiles (4 Ad Hoc and 4 Apple Store) and p12 file that you created copied to the same computer that you are using to upload your app to iTunes.


### PR DESCRIPTION
This PR adds a table of contents where appropriate and adds some rendering improvements.

We have done this in docs too which improves readability a lot.

The `\` before a URL helps finding broken links as it tells Antora to render it as text which is ok to example domains. The `\` it is an internal directive and will not be printed.

I harmonized the use of the `btn:` attribute to render click a button correctly. This was already present on some pages but not on all.

We did this in docs too, live example see: https://doc.owncloud.com/server/admin_manual/installation/system_requirements.html